### PR TITLE
feat: add compatibility for new auth mode

### DIFF
--- a/upload-file/upload/client.go
+++ b/upload-file/upload/client.go
@@ -51,6 +51,7 @@ func (c *Client) presignedUploadURL(ctx context.Context, destination string) (st
 	`)
 	req.Var("name", destination)
 	req.Header.Set("Authorization", c.securityAgentAPIKey)
+	req.Header.Set("X-Hasura-Auth-Mode", "ci-auth")
 
 	var response PresignedUploadResponse
 	err := c.gqlClient.Run(ctx, req, &response)


### PR DESCRIPTION
This is to make sure that the tool works both with older and newer builds where we have configured a different auth mode.