### PR TITLE
fix: safely skip associations if GH repo detail is not found

### DIFF
--- a/upload-file/scan/associate_github_branch_name.go
+++ b/upload-file/scan/associate_github_branch_name.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"log"
 	"os"
 	"strings"
 
@@ -17,6 +18,10 @@ func (s *Scan) AssociateGithubBranchName(ctx context.Context) (string, error) {
 	ghRepoID, err := catalog.GithubRepoID(ctx, s.client)
 	if err != nil {
 		return "", err
+	}
+	if ghRepoID == "" {
+		log.Println("Unable to associate GitHub branch. Try setting GITHUB_REPOSITORY environment variable if not already set.")
+		return "", nil
 	}
 
 	req := graphql.NewRequest(`mutation AssociateGitHubBranchName($scan_id: uuid!, $github_repo_id: uuid!, $github_branch_name: string!) {

--- a/upload-file/scan/associate_github_branch_name_test.go
+++ b/upload-file/scan/associate_github_branch_name_test.go
@@ -419,6 +419,88 @@ func TestScan_AssociateGithubBranchName_HTTPError(t *testing.T) {
 	}
 }
 
+func TestScan_AssociateGithubBranchName_EmptyGithubRepoID(t *testing.T) {
+	// Save original values
+	originalBuildkite := os.Getenv("BUILDKITE_BRANCH")
+	originalGithubRepo := os.Getenv("GITHUB_REPOSITORY")
+
+	// Set test environment - valid branch name but no GITHUB_REPOSITORY
+	os.Setenv("BUILDKITE_BRANCH", "feature/awesome-feature")
+	os.Unsetenv("GITHUB_REPOSITORY") // This will cause catalog.GithubRepoID to return empty string
+
+	// Restore original values
+	defer func() {
+		if originalBuildkite != "" {
+			os.Setenv("BUILDKITE_BRANCH", originalBuildkite)
+		} else {
+			os.Unsetenv("BUILDKITE_BRANCH")
+		}
+		if originalGithubRepo != "" {
+			os.Setenv("GITHUB_REPOSITORY", originalGithubRepo)
+		} else {
+			os.Unsetenv("GITHUB_REPOSITORY")
+		}
+	}()
+
+	client := saclient.NewClient("https://example.com/graphql", "test-api-key")
+	scan := &Scan{
+		ID:     "scan-id-123",
+		Tags:   map[string]string{},
+		client: client,
+	}
+
+	branchName, err := scan.AssociateGithubBranchName(context.Background())
+
+	if err != nil {
+		t.Errorf("AssociateGithubBranchName failed: %v", err)
+	}
+
+	if branchName != "" {
+		t.Errorf("Expected empty branch name when GitHub repo ID is empty, got %s", branchName)
+	}
+}
+
+func TestScan_AssociateGithubBranchName_EmptyGithubRepoID_InvalidFormat(t *testing.T) {
+	// Save original values
+	originalBuildkite := os.Getenv("BUILDKITE_BRANCH")
+	originalGithubRepo := os.Getenv("GITHUB_REPOSITORY")
+
+	// Set test environment - valid branch name but invalid GITHUB_REPOSITORY format
+	os.Setenv("BUILDKITE_BRANCH", "develop")
+	os.Setenv("GITHUB_REPOSITORY", "invalid-repo-format") // This will cause catalog.GithubRepoID to return empty string
+
+	// Restore original values
+	defer func() {
+		if originalBuildkite != "" {
+			os.Setenv("BUILDKITE_BRANCH", originalBuildkite)
+		} else {
+			os.Unsetenv("BUILDKITE_BRANCH")
+		}
+		if originalGithubRepo != "" {
+			os.Setenv("GITHUB_REPOSITORY", originalGithubRepo)
+		} else {
+			os.Unsetenv("GITHUB_REPOSITORY")
+		}
+	}()
+
+	client := saclient.NewClient("https://example.com/graphql", "test-api-key")
+	scan := &Scan{
+		ID:     "scan-id-123",
+		Tags:   map[string]string{},
+		client: client,
+	}
+
+	branchName, err := scan.AssociateGithubBranchName(context.Background())
+
+	if err != nil {
+		t.Errorf("AssociateGithubBranchName failed: %v", err)
+	}
+
+	if branchName != "" {
+		t.Errorf("Expected empty branch name when GitHub repo ID is empty due to invalid format, got %s", branchName)
+	}
+}
+
 func TestScan_AssociateGithubBranchName_ContextCancellation(t *testing.T) {
 	// Save original values
 	originalBuildkite := os.Getenv("BUILDKITE_BRANCH")

--- a/upload-file/scan/associate_github_pull_request.go
+++ b/upload-file/scan/associate_github_pull_request.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -18,6 +19,10 @@ func (s *Scan) AssociateGithubPullRequest(ctx context.Context) (int, error) {
 	ghRepoID, err := catalog.GithubRepoID(ctx, s.client)
 	if err != nil {
 		return 0, err
+	}
+	if ghRepoID == "" {
+		log.Println("Unable to associate GitHub pull request. Try setting GITHUB_REPOSITORY environment variable if not already set.")
+		return 0, nil
 	}
 
 	req := graphql.NewRequest(`mutation AssociateGitHubPullRequest($scan_id: uuid!, $github_repo_id: uuid!, $github_pr_number: int_32!) {

--- a/upload-file/scan/associate_github_pull_request_test.go
+++ b/upload-file/scan/associate_github_pull_request_test.go
@@ -491,6 +491,88 @@ func TestScan_AssociateGithubPullRequest_GraphQLError(t *testing.T) {
 	}
 }
 
+func TestScan_AssociateGithubPullRequest_EmptyGithubRepoID(t *testing.T) {
+	// Save original values
+	originalBuildkite := os.Getenv("BUILDKITE_PULL_REQUEST")
+	originalGithubRepo := os.Getenv("GITHUB_REPOSITORY")
+
+	// Set test environment - valid PR number but no GITHUB_REPOSITORY
+	os.Setenv("BUILDKITE_PULL_REQUEST", "456")
+	os.Unsetenv("GITHUB_REPOSITORY") // This will cause catalog.GithubRepoID to return empty string
+
+	// Restore original values
+	defer func() {
+		if originalBuildkite != "" {
+			os.Setenv("BUILDKITE_PULL_REQUEST", originalBuildkite)
+		} else {
+			os.Unsetenv("BUILDKITE_PULL_REQUEST")
+		}
+		if originalGithubRepo != "" {
+			os.Setenv("GITHUB_REPOSITORY", originalGithubRepo)
+		} else {
+			os.Unsetenv("GITHUB_REPOSITORY")
+		}
+	}()
+
+	client := saclient.NewClient("https://example.com/graphql", "test-api-key")
+	scan := &Scan{
+		ID:     "scan-id-123",
+		Tags:   map[string]string{},
+		client: client,
+	}
+
+	prNumber, err := scan.AssociateGithubPullRequest(context.Background())
+
+	if err != nil {
+		t.Errorf("AssociateGithubPullRequest failed: %v", err)
+	}
+
+	if prNumber != 0 {
+		t.Errorf("Expected PR number 0 when GitHub repo ID is empty, got %d", prNumber)
+	}
+}
+
+func TestScan_AssociateGithubPullRequest_EmptyGithubRepoID_InvalidFormat(t *testing.T) {
+	// Save original values
+	originalBuildkite := os.Getenv("BUILDKITE_PULL_REQUEST")
+	originalGithubRepo := os.Getenv("GITHUB_REPOSITORY")
+
+	// Set test environment - valid PR number but invalid GITHUB_REPOSITORY format
+	os.Setenv("BUILDKITE_PULL_REQUEST", "789")
+	os.Setenv("GITHUB_REPOSITORY", "invalid-repo-format") // This will cause catalog.GithubRepoID to return empty string
+
+	// Restore original values
+	defer func() {
+		if originalBuildkite != "" {
+			os.Setenv("BUILDKITE_PULL_REQUEST", originalBuildkite)
+		} else {
+			os.Unsetenv("BUILDKITE_PULL_REQUEST")
+		}
+		if originalGithubRepo != "" {
+			os.Setenv("GITHUB_REPOSITORY", originalGithubRepo)
+		} else {
+			os.Unsetenv("GITHUB_REPOSITORY")
+		}
+	}()
+
+	client := saclient.NewClient("https://example.com/graphql", "test-api-key")
+	scan := &Scan{
+		ID:     "scan-id-123",
+		Tags:   map[string]string{},
+		client: client,
+	}
+
+	prNumber, err := scan.AssociateGithubPullRequest(context.Background())
+
+	if err != nil {
+		t.Errorf("AssociateGithubPullRequest failed: %v", err)
+	}
+
+	if prNumber != 0 {
+		t.Errorf("Expected PR number 0 when GitHub repo ID is empty due to invalid format, got %d", prNumber)
+	}
+}
+
 func TestScan_AssociateGithubPullRequest_ContextCancellation(t *testing.T) {
 	// Save original values
 	originalBuildkite := os.Getenv("BUILDKITE_PULL_REQUEST")


### PR DESCRIPTION
There have been some instances of

```
2025/09/24 18:33:39 Failed to associate GitHub pull request with scan: graphql: error from data source: error returned from database: invalid input syntax for type uuid: ""
```