### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/upload-file/Dockerfile
+++ b/upload-file/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.24-alpine-stable AS builder
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary

Re-homes base images to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images` via floating `-stable` aliases. Per Hasura policy, every container deployed in Hasura infra must be pulled from this private registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.).

The `-stable` aliases are floating tags that auto-advance to the latest patched digest of the same version line, so images stay patched without version bumps.

## Exact FROM swaps

### `upload-file/Dockerfile`
- `FROM golang:1.24-alpine` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.24-alpine-stable`

(The `AS builder` suffix is preserved; only the image reference was swapped.)

## Notes

This is part of an org-wide **Phase 1** migration: exact-match swaps only — no version bumps, no reformatting, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)