### PR TITLE
chore: update the default security agent API endpoint

### DIFF
--- a/upload-file/action.yml
+++ b/upload-file/action.yml
@@ -19,7 +19,7 @@ inputs:
   security_agent_api_endpoint:
     description: "Security Agent API endpoint"
     required: false
-    default: https://sec-ql.agents-hasura.private-ddn.hasura.app/graphql
+    default: https://p-7428f407-1771.promptql-internal.pro.hasura.io/graphql
   security_agent_api_key:
     description: "Security Agent API key"
     required: true

--- a/upload-file/input/input.go
+++ b/upload-file/input/input.go
@@ -40,7 +40,7 @@ func Parse() (*Input, error) {
 
 	input.SecurityAgentAPIEndpoint = os.Getenv("INPUT_SECURITY_AGENT_API_ENDPOINT")
 	if input.SecurityAgentAPIEndpoint == "" {
-		input.SecurityAgentAPIEndpoint = "https://sec-ql.agents-hasura.private-ddn.hasura.app/graphql"
+		input.SecurityAgentAPIEndpoint = "https://p-7428f407-1771.promptql-internal.pro.hasura.io/graphql"
 	}
 
 	securityAgentAPIKey := os.Getenv("INPUT_SECURITY_AGENT_API_KEY")

--- a/upload-file/input/input_test.go
+++ b/upload-file/input/input_test.go
@@ -126,7 +126,7 @@ func TestParseSecurityAgentAPIEndpoint(t *testing.T) {
 			envEndpoint:      "",
 			envAPIKey:        "test-api-key",
 			envFilePath:      testFile,
-			expectedEndpoint: "https://sec-ql.agents-hasura.private-ddn.hasura.app/graphql",
+			expectedEndpoint: "https://p-7428f407-1771.promptql-internal.pro.hasura.io/graphql",
 			expectError:      false,
 		},
 		{
@@ -134,7 +134,7 @@ func TestParseSecurityAgentAPIEndpoint(t *testing.T) {
 			envEndpoint:      "", // Will be unset in test
 			envAPIKey:        "test-api-key",
 			envFilePath:      testFile,
-			expectedEndpoint: "https://sec-ql.agents-hasura.private-ddn.hasura.app/graphql",
+			expectedEndpoint: "https://p-7428f407-1771.promptql-internal.pro.hasura.io/graphql",
 			expectError:      false,
 		},
 	}


### PR DESCRIPTION
The security agent's DDN project and the data plane hosting it were deleted, and the project has been recreated on the `promptql` data plane (see hasura/security-agent#42). The old endpoint baked in as the default no longer resolves, so every consumer that relies on it has been failing its upload step since the deletion.

## Changes

The endpoint was hardcoded in two places, both updated to the new project's endpoint:

- `upload-file/action.yml` — the `security_agent_api_endpoint` input default
- `upload-file/input/input.go` — the fallback when `INPUT_SECURITY_AGENT_API_ENDPOINT` is empty

Plus the two expectations in `upload-file/input/input_test.go` that assert the default. `go test ./...` passes.

No auth change is needed: `saclient` already sends the token as a raw `Authorization` value together with `X-Hasura-Auth-Mode: ci-auth`, which is what the migrated engine expects, and the JWT signing key survived the migration.

## Verified

An upload through this path was confirmed working end to end against the new project (hasura/lux#9237 CI passing), with the endpoint overridden in the workflow. That override has since been dropped there in favour of this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)